### PR TITLE
better fastboot detection

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 
-const { inject: { service }, computed, A, isEmpty, typeOf } = Ember;
+const { inject: { service }, computed, computed: { reads }, A, isEmpty, typeOf } = Ember;
 
 export default Ember.Service.extend({
   fastboot: service(),
 
-  _isFastboot: computed.notEmpty('fastboot._fastbootInfo'),
+  _isFastboot: reads('fastboot.isFastBoot'),
 
   _documentCookies: computed(function() {
     const all = document.cookie.split(';');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli": "2.4.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-fastboot": "0.6.0",
+    "ember-cli-fastboot": "0.6.1",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",


### PR DESCRIPTION
This uses the fastboot service's isFastBoot property to detect whether the app is currently running in FastBoot context rather than relying on the presence of a private property in the service.