### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-lodash": "0.0.6",
     "ember-mocha": "0.8.11",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.0",
@@ -57,7 +56,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "~1.0.1"
+    "ember-getowner-polyfill": "~1.0.1",
+    "ember-lodash": "0.0.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
ember-cli-addon-tests is now used from the official repo instead of the fork and ember-lodash is an actual dependency instead of a devDependency.

closes #11 