### PR TITLE
it's FastBoot with a capital B

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 `ember-cookies` implements an abstract __cookie API that works both in the
 browser (via `document.cookie`) as well as with Fastboot in the server
-context__ (using the `request` and `response` accessible via the `fastboot`
+context__ (using the `request` and `response` accessible via the `fastBoot`
 service).
 
-__Having access to cookies both in the browser as well as in Fastboot is key to
+__Having access to cookies both in the browser as well as in FastBoot is key to
 being able to share a common session.__
 
 __This is currently still in a very early stage. While the dummy app works, the

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -6,12 +6,12 @@ import _collection from 'lodash/collection';
 const { computed, computed: { reads }, isEmpty, typeOf, isNone, assert } = Ember;
 
 export default Ember.Service.extend({
-  _isFastboot: reads('_fastboot.isFastBoot'),
+  _isFastBoot: reads('_fastBoot.isFastBoot'),
 
-  _fastboot: computed(function() {
+  _fastBoot: computed(function() {
     let owner = getOwner(this);
 
-    return owner.lookup('service:fastboot');
+    return owner.lookup('service:fastBoot');
   }),
 
   _document: computed(function() {
@@ -30,24 +30,24 @@ export default Ember.Service.extend({
     }, {});
   }).volatile(),
 
-  _fastbootCookies: computed(function() {
-    let fastbootCookiesCache = this.get('_fastbootCookiesCache');
-    let fastbootCookies;
+  _fastBootCookies: computed(function() {
+    let fastBootCookiesCache = this.get('_fastBootCookiesCache');
+    let fastBootCookies;
 
-    if (!fastbootCookiesCache) {
-      fastbootCookies = this.get('_fastboot.cookies');
-      this.set('_fastbootCookiesCache', fastbootCookies);
+    if (!fastBootCookiesCache) {
+      fastBootCookies = this.get('_fastBoot.cookies');
+      this.set('_fastBootCookiesCache', fastBootCookies);
     } else {
-      fastbootCookies = this._filterCachedFastbootCookies(fastbootCookiesCache);
+      fastBootCookies = this._filterCachedFastBootCookies(fastBootCookiesCache);
     }
 
-    return fastbootCookies;
+    return fastBootCookies;
   }).volatile(),
 
   read(name) {
     let all;
-    if (this.get('_isFastboot')) {
-      all = this.get('_fastbootCookies');
+    if (this.get('_isFastBoot')) {
+      all = this.get('_fastBootCookies');
     } else {
       all = this.get('_documentCookies');
     }
@@ -65,8 +65,8 @@ export default Ember.Service.extend({
     assert('Cookies cannot be set with both maxAge and an explicit expiration time!', isEmpty(options.expires) || isEmpty(options.maxAge));
     value = this._encodeValue(value);
 
-    if (this.get('_isFastboot')) {
-      this._writeFastbootCookie(name, value, options);
+    if (this.get('_isFastBoot')) {
+      this._writeFastBootCookie(name, value, options);
     } else {
       this._writeDocumentCookie(name, value, options);
     }
@@ -93,19 +93,19 @@ export default Ember.Service.extend({
     this.set('_document.cookie', cookie);
   },
 
-  _writeFastbootCookie(name, value, options = {}) {
+  _writeFastBootCookie(name, value, options = {}) {
     if (!isEmpty(options.maxAge)) {
       options.maxAge = options.maxAge * 1000;
     }
 
-    this._cacheFastbootCookie(...arguments);
+    this._cacheFastBootCookie(...arguments);
 
-    let response = this.get('_fastboot._fastbootInfo.response');
+    let response = this.get('_fastBoot._fastBootInfo.response');
     response.cookie(name, value, options);
   },
 
-  _cacheFastbootCookie(name, value, options = {}) {
-    let fastbootCache = this.getWithDefault('_fastbootCookiesCache', {});
+  _cacheFastBootCookie(name, value, options = {}) {
+    let fastBootCache = this.getWithDefault('_fastBootCookiesCache', {});
     let cachedOptions = _object.assign({}, options);
 
     if (cachedOptions.maxAge) {
@@ -115,13 +115,13 @@ export default Ember.Service.extend({
       delete cachedOptions.maxAge;
     }
 
-    fastbootCache[name] = { value, options: cachedOptions };
-    this.set('_fastbootCookiesCache', fastbootCache);
+    fastBootCache[name] = { value, options: cachedOptions };
+    this.set('_fastBootCookiesCache', fastBootCache);
   },
 
-  _filterCachedFastbootCookies(fastbootCookiesCache) {
-    let request = this.get('_fastboot._fastbootInfo.request');
-    return _collection.reduce(fastbootCookiesCache, (acc, cookie, name) => {
+  _filterCachedFastBootCookies(fastBootCookiesCache) {
+    let request = this.get('_fastBoot._fastBootInfo.request');
+    return _collection.reduce(fastBootCookiesCache, (acc, cookie, name) => {
       let { value, options } = cookie;
       options = options || {};
 

--- a/node-tests/acceptance/cookie-access-test.js
+++ b/node-tests/acceptance/cookie-access-test.js
@@ -28,7 +28,7 @@ describe('cookies access', function() {
     return app.stopServer();
   });
 
-  it('reads and writes cookies in Fastboot', function() {
+  it('reads and writes cookies in FastBoot', function() {
     return app.startServer({
       command: 'fastboot'
     }).then(function() {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -216,10 +216,10 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
     });
   });
 
-  describe('in the Fastboot server', function() {
+  describe('in the FastBoot server', function() {
     beforeEach(function() {
-      this.fakeFastboot = {
-        _fastbootInfo: {
+      this.fakeFastBoot = {
+        _fastBootInfo: {
           response: {
             cookie() {}
           },
@@ -228,15 +228,15 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
         cookies: {}
       };
       this.subject().setProperties({
-        _isFastboot: true,
-        _fastboot: this.fakeFastboot
+        _isFastBoot: true,
+        _fastBoot: this.fakeFastBoot
       });
     });
 
     describe('reading a cookie', function() {
       it('returns the cookie value', function() {
         let value = randomString();
-        this.fakeFastboot.cookies[COOKIE_NAME] = value;
+        this.fakeFastBoot.cookies[COOKIE_NAME] = value;
 
         expect(this.subject().read(COOKIE_NAME)).to.eq(value);
       });
@@ -246,14 +246,14 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('returns undefined for a cookie that was written for another path', function() {
-        this.fakeFastboot._fastbootInfo.request.path = '/path';
+        this.fakeFastBoot._fastBootInfo.request.path = '/path';
         this.subject().write(COOKIE_NAME, 'value', { path: '/some-other-path' });
 
         expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
       });
 
       it('returns the cookie value for a cookie that was written for the same path', function() {
-        this.fakeFastboot._fastbootInfo.request.path = '/path';
+        this.fakeFastBoot._fastBootInfo.request.path = '/path';
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { path: '/path' });
 
@@ -261,14 +261,14 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('returns undefined for a cookie that was written for another domain', function() {
-        this.fakeFastboot._fastbootInfo.request.hostname = 'example.com';
+        this.fakeFastBoot._fastBootInfo.request.hostname = 'example.com';
         this.subject().write(COOKIE_NAME, 'value', { domain: 'another-domain.com' });
 
         expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
       });
 
       it('returns the cookie value for a cookie that was written for the same domain', function() {
-        this.fakeFastboot._fastbootInfo.request.hostname = 'example.com';
+        this.fakeFastBoot._fastBootInfo.request.hostname = 'example.com';
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { domain: 'example.com' });
 
@@ -276,7 +276,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('returns the cookie value for a cookie that was written for a parent domain', function() {
-        this.fakeFastboot._fastbootInfo.request.hostname = 'sub.example.com';
+        this.fakeFastBoot._fastBootInfo.request.hostname = 'sub.example.com';
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { domain: 'example.com' });
 
@@ -312,14 +312,14 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('returns undefined for a cookie that was written for another protocol (secure cookies vs. non-secure request)', function() {
-        this.fakeFastboot._fastbootInfo.request.hostname = 'http';
+        this.fakeFastBoot._fastBootInfo.request.hostname = 'http';
         this.subject().write(COOKIE_NAME, 'value', { secure: true });
 
         expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
       });
 
       it('returns the cookie value for a cookie that was written for the same protocol', function() {
-        this.fakeFastboot._fastbootInfo.request.protocol = 'https';
+        this.fakeFastBoot._fastBootInfo.request.protocol = 'https';
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { secure: true });
 
@@ -333,7 +333,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       it('writes the value', function() {
         let value = randomString();
 
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue) {
           expect(name).to.eq(COOKIE_NAME);
           expect(theValue).to.eq(value);
         };
@@ -344,7 +344,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       it('URI-component-encodes the value', function() {
         let value = '!"§$%&/()=?"';
 
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue) {
           expect(theValue).to.eq(encodeURIComponent(value));
         };
 
@@ -352,7 +352,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('sets the cookie domain', function() {
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue, options) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue, options) {
           expect(options.domain).to.eq('example.com');
         };
 
@@ -361,7 +361,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
 
       it('sets the expiration', function() {
         let date = new Date();
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue, options) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue, options) {
           expect(options.expires).to.eq(date);
         };
 
@@ -369,7 +369,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('sets the max age', function() {
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue, options) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue, options) {
           expect(options.maxAge).to.eq(1000);
         };
 
@@ -377,7 +377,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('sets the secure flag', function() {
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue, options) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue, options) {
           expect(options.secure).to.be.true;
         };
 
@@ -385,7 +385,7 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
       });
 
       it('sets the path', function() {
-        this.fakeFastboot._fastbootInfo.response.cookie = function(name, theValue, options) {
+        this.fakeFastBoot._fastBootInfo.response.cookie = function(name, theValue, options) {
           expect(options.path).to.eq('/sample-path');
         };
 


### PR DESCRIPTION
This corrects all occurences of `fastboot` or `Fastboot` to `fastBoot` or `FastBoot` instead.