### PR TITLE
Update to use the FastBoot service's public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cookies",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Cookies abstraction for Ember.js that works both in the browser as well as with Fastboot on the server.",
   "directories": {
     "doc": "doc",
@@ -27,7 +27,7 @@
     "ember-cli-addon-tests": "tomdale/ember-cli-addon-tests",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-fastboot": "0.6.1",
+    "ember-cli-fastboot": "0.6.2",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",


### PR DESCRIPTION
@marcoow I updated ember-cookies to use `FastBootRequest` and `FastBootResponse`.