### PR TITLE
Fix usage of fastboot host

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -120,7 +120,10 @@ export default Ember.Service.extend({
   },
 
   _filterCachedFastBootCookies(fastBootCookiesCache) {
-    let { host, path: requestPath, protocol } = this.get('_fastBoot.request');
+    let { path: requestPath, protocol } = this.get('_fastBoot.request');
+
+    // cannot use deconstruct here
+    let host = this.get('_fastBoot.request.host');
 
     return A(keys(fastBootCookiesCache)).reduce((acc, name) => {
       let { value, options } = fastBootCookiesCache[name];

--- a/node-tests/acceptance/cookie-access-test.js
+++ b/node-tests/acceptance/cookie-access-test.js
@@ -30,7 +30,8 @@ describe('cookies access', function() {
 
   it('reads and writes cookies in FastBoot', function() {
     return app.startServer({
-      command: 'fastboot'
+      command: 'fastboot',
+      additionalArguments: ['--host 0.0.0.0']
     }).then(function() {
       var value = Math.random().toString(36).substring(2);
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-addon-tests": "tomdale/ember-cli-addon-tests",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-fastboot": "1.0.0-beta.4",
+    "ember-cli-fastboot": "1.0.0-beta.7",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.1",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.3",
-    "ember-cli-addon-tests": "tomdale/ember-cli-addon-tests",
+    "ember-cli-addon-tests": "^0.3.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-fastboot": "1.0.0-beta.7",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,10 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    fastboot: {
+      hostWhitelist: [/^localhost:\d+$/]
     }
   };
 


### PR DESCRIPTION
**TL;DR**

- Fix host.
- Upgrade `ember-cli-fastboot`.
- Add hostWhitelist to dummy app config.
- Add domain to dummy app test on writing cookies.

**Details**

When writing a cookie with domain, in fastboot land, it breaks

It seems that we cannot use  ES6 deconstruct to get host from `fastboot.request` it was returning an object containing: 

```js
Descriptor {
  isDescriptor: true,
  _getter: [Function],
  _dependentKeys: undefined,
  _suspended: undefined,
  _meta: undefined,
  _volatile: false,
  _readOnly: false }
```
However, when we call `this.get('_fastBoot.request.host')` it returns what is expected.

It would be nice to have tests for the `write` cookies with domain, but not sure how. I would love some guidance on that. 
