### PR TITLE
Fix cases when cookie value has '=' signs in them

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -31,7 +31,10 @@ export default Ember.Service.extend({
     return A(all).reduce((acc, cookie) => {
       if (!isEmpty(cookie)) {
         let [key, value] = cookie.split(/=(.+)?/);
-        acc[key.trim()] = value.trim();
+        
+        if (key && value) {
+          acc[key.trim()] = value.trim();
+        }               
       }
       return acc;
     }, {});

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -30,7 +30,7 @@ export default Ember.Service.extend({
 
     return A(all).reduce((acc, cookie) => {
       if (!isEmpty(cookie)) {
-        let [key, value] = cookie.split('=');
+        let [key, value] = cookie.split(/=(.+)?/);
         acc[key.trim()] = value.trim();
       }
       return acc;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cookies",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "description": "Cookies abstraction for Ember.js that works both in the browser as well as with Fastboot on the server.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Fixed cases when you have a string that ends with == (like in my case a token). See example

**TOKEN:**
WOOWAUTH:V0VCU0lURV9UT0tFTjoyZmZmZGQ2MC1hNTQ5LTExZTMtYTk3NS0yMzdjYmVlMjNlZDk6MTQ4MjQxNTI2MDg5NTrvv70X77+9D++/vRHvv71d77+9IO+/ve+/vX4BMe+/ve+/vQ==

**RETURN RESULT:**
WOOWAUTH:V0VCU0lURV9UT0tFTjoyZmZmZGQ2MC1hNTQ5LTExZTMtYTk3NS0yMzdjYmVlMjNlZDk6MTQ4MjQxNTI2MDg5NTrvv70X77+9D++/vRHvv71d77+9IO+/ve+/vX4BMe+/ve+/vQ

Missing == at the end.