### PR TITLE
_filterCachedFastBootCookies: don't crash when requestPath is nully

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -131,7 +131,7 @@ export default Ember.Service.extend({
 
       let { path: optionsPath, domain, expires, secure } = options;
 
-      if (optionsPath && requestPath.indexOf(optionsPath) !== 0) {
+      if (optionsPath && requestPath && requestPath.indexOf(optionsPath) !== 0) {
         return acc;
       }
 

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -285,6 +285,14 @@ describeModule('service:cookies', 'CookiesService', {}, function() {
         expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
       });
 
+      it('does not crash for nully path', function() {
+        this.fakeFastBoot.request.path = undefined;
+        let value = randomString();
+        this.subject().write(COOKIE_NAME, value, { path: '/path' });
+
+        expect(this.subject().read(COOKIE_NAME)).to.eq(value);
+      });
+
       it('returns the cookie value for a cookie that was written for the same path', function() {
         this.fakeFastBoot.request.path = '/path';
         let value = randomString();


### PR DESCRIPTION
Ran into this issue using https://github.com/robwebdev/ember-cli-staticboot .

Added a tiny check that prevents the crash.