### PR TITLE
Allow options when deleting cookie

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -82,8 +82,9 @@ export default Ember.Service.extend({
     }
   },
 
-  clear(name) {
-    this.write(name, null, { expires: new Date('1970-01-01') });
+  clear(name, options = {}) {
+    options.expires = new Date('1970-01-01');
+    this.write(name, null, options);
   },
 
   _writeDocumentCookie(name, value, options = {}) {


### PR DESCRIPTION
When using `.clear(COOKIE_NAME}`, there should be a way to specify options such as "path" and "domain". Otherwise a cookie might persist if you try to delete it from a different route than the one you set it on.

I believe the most common use case is that, after the user logs in, you want to set a cookie which persists on every route (therefore specifying "/" as the path). Then, if you log out, you need to specify the path "/" for the cookie if you log out from a route that's not "/".