### PR TITLE
Allow clear to receive options

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -82,8 +82,9 @@ export default Ember.Service.extend({
     }
   },
 
-  clear(name) {
-    this.write(name, null, { expires: new Date('1970-01-01') });
+  clear(name, options = {}) {
+    options = Object.assign({}, options, { expires: new Date('1970-01-01') });
+    this.write(name, null, options);
   },
 
   _writeDocumentCookie(name, value, options = {}) {


### PR DESCRIPTION
This PR allows passing options to the `clear` method.

This makes possible to clear cookies from the current top domain, using something like `this.get('cookies').clear('MY_KEY', { domain: URI().domain() });`

