### PR TITLE
Fixes invalid cookies

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -4,6 +4,7 @@ const {
   computed,
   computed: { reads },
   isEmpty,
+  isPresent,
   typeOf,
   isNone,
   assert,
@@ -26,11 +27,12 @@ export default Ember.Service.extend({
   }),
 
   _documentCookies: computed(function() {
-    let all = this.get('_document.cookie').split(';');
+    let all      = this.get('_document.cookie').split(';');
+    let filtered = this._filterDocumentCookies(A(all));
 
-    return A(all).reduce((acc, cookie) => {
+    return filtered.reduce((acc, cookie) => {
       if (!isEmpty(cookie)) {
-        let [key, value] = cookie.split('=');
+        let [key, value] = cookie;
         acc[key.trim()] = value.trim();
       }
       return acc;
@@ -166,6 +168,11 @@ export default Ember.Service.extend({
     } else {
       return decodeURIComponent(value);
     }
+  },
+
+  _filterDocumentCookies(unfilteredCookies) {
+    return unfilteredCookies.map((c) => c.split('='))
+      .filter((c) => isPresent(c[0]) && isPresent(c[1]));
   },
 
   _serializeCookie(name, value, options = {}) {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -74,6 +74,11 @@ describe('CookiesService', function() {
         expect(afterRoundtrip).to.eq(value);
       });
 
+      it('handles invalid values for cookies', function() {
+        document.cookie = '=blank';
+        expect(this.subject().read('blank')).to.be.blank;
+      });
+
       it('returns undefined when the cookie does not exist', function() {
         let afterRoundtrip = this.subject().read('does-not-exist');
 

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -76,7 +76,7 @@ describe('CookiesService', function() {
 
       it('handles invalid values for cookies', function() {
         document.cookie = '=blank';
-        expect(this.subject().read('')).to.be.blank;
+        expect(this.subject().read('')).to.deep.equal({});
       });
 
       it('returns undefined when the cookie does not exist', function() {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -76,7 +76,7 @@ describe('CookiesService', function() {
 
       it('handles invalid values for cookies', function() {
         document.cookie = '=blank';
-        expect(this.subject().read('blank')).to.be.blank;
+        expect(this.subject().read('')).to.be.blank;
       });
 
       it('returns undefined when the cookie does not exist', function() {


### PR DESCRIPTION
In some browsers we're seeing invalid cookies kill our application.
I don't really like guarding for things like this, but I'd rather guard
than have a flaky application. Thoughts?

We've seen this behavior on both IE11 and Edge on Windows 7 and Windows
10.