### PR TITLE
Add options to args for clear() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The `cookies` service has methods for reading and writing cookies:
   `String`.
 * `write(name, value, options = {})`: writes a cookie with the given name and
   value; options can be used to set `domain`, `expires`, `path` and `secure`.
-* `clear(name, options = {})`: clears the cookie so that future reads do not return a value;
-  options can be used to specify `domain`, `path` or `secure`.
+* `clear(name, options = {})`: clears the cookie so that future reads do not
+  return a value; options can be used to specify `domain`, `path` or `secure`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The `cookies` service has methods for reading and writing cookies:
   `String`.
 * `write(name, value, options = {})`: writes a cookie with the given name and
   value; options can be used to set `domain`, `expires`, `path` and `secure`.
-* `clear(name)`: clears the cookie so that future reads do not return a value;
+* `clear(name, options = {})`: clears the cookie so that future reads do not return a value;
   options can be used to specify `domain`, `path` or `secure`.
 
 ## License


### PR DESCRIPTION
Adds the optional `options` arg to `clear()` in the README