### PR TITLE
CI: Run on Node 4 and 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "stable"
+  - "6"
   - "4"
 
 sudo: required


### PR DESCRIPTION
"stable" is 8 now, which seems to cause some issues somewhere. This should hopefully fix the CI builds.