### PR TITLE
fix: set fake document on service in tests

### DIFF
--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -71,7 +71,7 @@ describe('CookiesService', function() {
         }
         // jscs:enable requireEnhancedObjectLiterals
       };
-      this.subject().setProperties('_document', this.fakeDocument);
+      this.subject().set('_document', this.fakeDocument);
     });
 
     afterEach(function() {
@@ -279,7 +279,7 @@ describe('CookiesService', function() {
         });
 
         it('clears the cookie set for a given path', function() {
-          let path = '/';
+          let path = document.location.pathname;
           let value = randomString();
           this.subject().write(COOKIE_NAME, value, { path });
 


### PR DESCRIPTION
- Previously accidentally using setProperties, so the expectations were not being run in the browser write cookies tests.

closes #73 