### PR TITLE
Remove ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0",
-    "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+    "ember-cli-babel": "^6.6.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
As stated by deprecation warning and https://github.com/rwjblue/ember-getowner-polyfill#applications, the polyfill is no longer required.