### PR TITLE
work with both "https" and "https:" protocols

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -143,7 +143,7 @@ export default Service.extend({
         return acc;
       }
 
-      if (secure && protocol !== 'https') {
+      if (secure && !(protocol || '').match(/^https/)) {
         return acc;
       }
 

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -440,8 +440,16 @@ describe('CookiesService', function() {
         expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
       });
 
-      it('returns the cookie value for a cookie that was written for the same protocol', function() {
+      it('returns the cookie value for a cookie that was written for the same protocol ("https")', function() {
         this.fakeFastBoot.request.protocol = 'https';
+        let value = randomString();
+        this.subject().write(COOKIE_NAME, value, { secure: true });
+
+        expect(this.subject().read(COOKIE_NAME)).to.eq(value);
+      });
+
+      it('returns the cookie value for a cookie that was written for the same protocol ("https:")', function() {
+        this.fakeFastBoot.request.protocol = 'https:';
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { secure: true });
 


### PR DESCRIPTION
FastBoot recently changed the string value of the `protocol` property for HTTPS requests from `'https'` to `'https:'` which breaks HTTPS detection in ember-cookies. This PR changes that detection so that it treats both `'https'` and `'https:'` as HTTPS and thus works correctly with new and old FastBoot versions.

closes #131 