### PR TITLE
Add useRawValue option to avoid encoding/decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ export default Ember.Controller.extend({
 
 The `cookies` service has methods for reading and writing cookies:
 
-* `read(name)`: reads the cookie with the given name, returns its value as a
-  `String`.
+* `read(name, options = {})`: reads the cookie with the given name, returns its value as a
+  `String`; options can be used to set `raw` (boolean, disables URL-decoding the value).
 * `write(name, value, options = {})`: writes a cookie with the given name and
-  value; options can be used to set `domain`, `expires` (Date), `maxAge` (time in seconds), `path` and `secure`.
+  value; options can be used to set `domain`, `expires` (Date), `maxAge` (time in seconds), `path`, `secure`,
+  and `raw` (boolean, disables URL-encoding the value).
 * `clear(name, options = {})`: clears the cookie so that future reads do not
   return a value; options can be used to specify `domain`, `path` or `secure`.
 


### PR DESCRIPTION
This commit adds a new `encodeValue` option to ember-cookies. I made it `true` by default to match current behavior. When it is set to `false`, it bypasses encoding the value of the cookie, in case that behavior is not desired by the user.

I personally have a scenario where I don't want the cookie to be encoded automatically, hence making this change.