### PR TITLE
Fix Object.assign error in IE11

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -5,8 +5,9 @@ import { assert } from '@ember/debug';
 import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
 import Service from '@ember/service';
-import { merge } from '@ember/polyfills';
-const { keys, assign } = Object;
+import { merge, assign as emberAssign } from '@ember/polyfills';
+const { keys } = Object;
+const assign = Object.assign || emberAssign || merge;
 const DEFAULTS = { raw: false };
 
 export default Service.extend({


### PR DESCRIPTION
Closes #145 

This just does the classic Ember.assign fallback if Object.assign isn't defined (i.e. in IE ;)