### PR TITLE
fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "6"
   - "4"
 
+sudo: required
 dist: trusty
 
 addons:


### PR DESCRIPTION
It seems there's a regression in Travis itself that can be fixed by setting `sudo: required` - see https://github.com/travis-ci/travis-ci/issues/8836