### PR TITLE
Add method to check whether a cookie exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ export default Ember.Controller.extend({
 
 The `cookies` service has methods for reading and writing cookies:
 
-* `read(name, options = {})`: reads the cookie with the given name, returns its value as a
-  `String`; options can be used to set `raw` (boolean, disables URL-decoding the value).
+* `read(name, options = {})`: reads the cookie with the given name, returns its
+  value as a `String`; options can be used to set `raw` (boolean, disables
+  URL-decoding the value).
 * `write(name, value, options = {})`: writes a cookie with the given name and
-  value; options can be used to set `domain`, `expires` (Date), `maxAge` (time in seconds), `path`, `secure`,
-  and `raw` (boolean, disables URL-encoding the value).
+  value; options can be used to set `domain`, `expires` (Date), `maxAge` (time
+  in seconds), `path`, `secure`, and `raw` (boolean, disables URL-encoding the
+  value).
 * `clear(name, options = {})`: clears the cookie so that future reads do not
   return a value; options can be used to specify `domain`, `path` or `secure`.
+* `exists(name)`: checks whether a cookie exists at all (even with a falsy
+  value) and returns `true` if that is the case or `false` otherwise.
 
 ## License
 

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -30,7 +30,7 @@ export default Service.extend({
     return filtered.reduce((acc, cookie) => {
       if (!isEmpty(cookie)) {
         let [key, value] = cookie;
-        acc[key.trim()] = value.trim();
+        acc[key.trim()] = (value || '').trim();
       }
       return acc;
     }, {});
@@ -90,6 +90,17 @@ export default Service.extend({
 
     options.expires = new Date('1970-01-01');
     this.write(name, null, options);
+  },
+
+  exists(name) {
+    let all;
+    if (this.get('_isFastBoot')) {
+      all = this.get('_fastBootCookies');
+    } else {
+      all = this.get('_documentCookies');
+    }
+
+    return all.hasOwnProperty(name);
   },
 
   _writeDocumentCookie(name, value, options = {}) {
@@ -178,7 +189,7 @@ export default Service.extend({
 
   _filterDocumentCookies(unfilteredCookies) {
     return unfilteredCookies.map((c) => c.split('='))
-      .filter((c) => isPresent(c[0]) && isPresent(c[1]));
+      .filter((c) => c.length === 2 && isPresent(c[0]));
   },
 
   _serializeCookie(name, value, options = {}) {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -138,8 +138,9 @@ describe('CookiesService', function() {
         expect(afterRoundtrip).to.eq(value);
       });
 
-      it('handles invalid values for cookies', function() {
+      it('handles invalid cookies', function() {
         document.cookie = '=blank';
+
         expect(this.subject().read('')).to.deep.equal({});
       });
 
@@ -387,6 +388,25 @@ describe('CookiesService', function() {
 
         expect(this.subject().read('test1')).to.be.empty;
         expect(this.subject().read('test2')).to.be.empty;
+      });
+    });
+
+    describe("checking for a cookie's existence", function() {
+      it('returns true when the cookie exists', function() {
+        let value = randomString();
+        document.cookie = `${COOKIE_NAME}=${value};`;
+
+        expect(this.subject().exists(COOKIE_NAME)).to.be.true;
+      });
+
+      it('returns true when the cookie exists with a falsy value', function() {
+        document.cookie = `${COOKIE_NAME}=;`;
+
+        expect(this.subject().exists(COOKIE_NAME)).to.be.true;
+      });
+
+      it('returns false when the cookie does not exist', function() {
+        expect(this.subject().exists(COOKIE_NAME)).to.be.false;
       });
     });
 
@@ -705,6 +725,25 @@ describe('CookiesService', function() {
 
           expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
         });
+      });
+    });
+
+    describe("checking for a cookie's existence", function() {
+      it('returns true when the cookie exists', function() {
+        let value = randomString();
+        this.subject().write(COOKIE_NAME, value);
+
+        expect(this.subject().exists(COOKIE_NAME)).to.be.true;
+      });
+
+      it('returns true when the cookie exists with a falsy value', function() {
+        this.subject().write(COOKIE_NAME);
+
+        expect(this.subject().exists(COOKIE_NAME)).to.be.true;
+      });
+
+      it('returns false when the cookie does not exist', function() {
+        expect(this.subject().exists(COOKIE_NAME)).to.be.false;
       });
     });
 


### PR DESCRIPTION
It is currently not possible to check whether a cookie exists at all (even with a falsy value like `cookie=`). That is due to the fact that we [filter the cookies (at least document cookies) to only includes the ones where both key and value are present](https://github.com/simplabs/ember-cookies/blob/master/addon/services/cookies.js#L181).

This adds an `exists` method to the cookies service that behaves like this:

```js
document.cookie = 'test=';
$E.exists('test'); // returns true
```