### PR TITLE
test in Firefox on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ dist: trusty
 
 addons:
   chrome: stable
+  firefox: latest
 
 cache:
   yarn: true

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -84,6 +84,8 @@ export default Service.extend({
       this._writeFastBootCookie(name, value, options);
     } else {
       assert('Cookies cannot be set to be HTTP-only from a browser!', !options.httpOnly);
+
+      options.path = options.path || this._normalizedDefaultPath();
       this._writeDocumentCookie(name, value, options);
     }
   },
@@ -93,6 +95,7 @@ export default Service.extend({
     assert('Expires, Max-Age, and raw options cannot be set when clearing cookies', isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.raw));
 
     options.expires = new Date('1970-01-01');
+    options.path = options.path || this._normalizedDefaultPath();
     this.write(name, null, options);
   },
 
@@ -252,6 +255,12 @@ export default Service.extend({
     }
 
     return _byteCount < MAX_COOKIE_BYTE_LENGTH;
-  }
+  },
 
+  _normalizedDefaultPath() {
+    if (!this.get('_isFastBoot')) {
+      let pathname = window.location.pathname;
+      return pathname.substring(0, pathname.lastIndexOf('/'));
+    }
+  }
 });

--- a/testem.js
+++ b/testem.js
@@ -5,12 +5,19 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'Chrome'
+    'Chrome',
+    'Firefox'
   ],
   launch_in_dev: [
     'Chrome'
   ],
   browser_args: {
+    Firefox: {
+      mode: 'ci',
+      args: [
+        '-headless'
+      ]
+    },
     Chrome: {
       mode: 'ci',
       args: [

--- a/testem.js
+++ b/testem.js
@@ -9,7 +9,8 @@ module.exports = {
     'Firefox'
   ],
   launch_in_dev: [
-    'Chrome'
+    'Chrome',
+    'Firefox'
   ],
   browser_args: {
     Firefox: {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -101,8 +101,11 @@ describe('CookiesService', function() {
     });
 
     afterEach(function() {
+      let pathname = window.location.pathname;
+      pathname = pathname.substring(0, pathname.lastIndexOf('/'));
       document.cookie = `${COOKIE_NAME}=whatever; expires=${new Date(0).toUTCString()}`;
-      document.cookie = `${COOKIE_NAME}=whatever; path=${window.location.pathname}; expires=${new Date(0).toUTCString()}`;
+      document.cookie = `${COOKIE_NAME}=whatever; path=${pathname}; expires=${new Date(0).toUTCString()}`;
+      document.cookie = `${COOKIE_NAME}=whatever; path=${pathname}/; expires=${new Date(0).toUTCString()}`;
     });
 
     describe('reading a cookie', function() {
@@ -152,6 +155,7 @@ describe('CookiesService', function() {
 
       it('returns the cookie value for a cookie that was written for the same path', function() {
         let path = window.location.pathname;
+        path = path.substring(0, path.lastIndexOf('/'));
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { path });
 
@@ -328,7 +332,9 @@ describe('CookiesService', function() {
 
       it('clears the cookie', function() {
         let value = randomString();
-        document.cookie = `${COOKIE_NAME}=${value};`;
+        let pathname = window.location.pathname;
+        let path = pathname.substring(0, pathname.lastIndexOf('/'));
+        document.cookie = `${COOKIE_NAME}=${value}; path=${path};`;
 
         expect(this.subject().read(COOKIE_NAME)).to.eq(value);
 


### PR DESCRIPTION
This adds Firefox to the browsers we test with in CI; see https://github.com/simplabs/ember-cookies/issues/152#issuecomment-377833332

It also includes a fix for a bug (or different behavior compared to Chrome) in Firefox: Firefox will set the default cookie path with a trailing slash (e.g. `/some/path/`) while Chrome would set it without the trailing slash (e.g. `/some/path`). In order to make the behavior the same for all browsers, this changes the `cookies` service so that it would automatically set a normalized default `path` (`/some/path` in the above example) if none was specified. I'm not really happy with this (as writing a cookie via the `cookies` service will now result in a different cookie than just using `document.cookie =`) but couldn't really think of a better solution 🤔 