### PR TITLE
Clone options hash to avoid mutating original options hash

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -90,6 +90,7 @@ export default Service.extend({
   },
 
   clear(name, options = {}) {
+    options = assign({}, options || {});
     assert('Expires, Max-Age, and raw options cannot be set when clearing cookies', isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.raw));
 
     options.expires = new Date('1970-01-01');


### PR DESCRIPTION
Read and write currently clone the options hash that comes in. Clear doesn't. Even though it doesn't have defaults, the cloning does prevent confusion when testing. Our application had an options hash we were passing into the `clear` method, and when we did, it would add on the `expires = new Date('1970-01-01')` to it. When we called `clear` again with the same options hash, it would fail because of the `assert` above (`assert('Expires, Max-Age, and raw options cannot be set when clearing cookies', isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.raw));`).