### PR TITLE
Fix Fastboot cookie caching

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -38,7 +38,7 @@ export default Service.extend({
   }).volatile(),
 
   _fastBootCookies: computed(function() {
-    let fastBootCookiesCache = this.get('_fastBootCookiesCache');
+    let fastBootCookiesCache = this._fastBootCookiesCache;
 
     if (!fastBootCookiesCache) {
       let fastBootCookies = this.get('_fastBoot.request.cookies');
@@ -47,7 +47,7 @@ export default Service.extend({
         acc[name] = { value };
         return acc;
       }, {});
-      this.set('_fastBootCookiesCache', fastBootCookiesCache);
+      this._fastBootCookiesCache = fastBootCookiesCache;
     }
 
     return this._filterCachedFastBootCookies(fastBootCookiesCache);
@@ -127,7 +127,7 @@ export default Service.extend({
   },
 
   _cacheFastBootCookie(name, value, options = {}) {
-    let fastBootCache = this.getWithDefault('_fastBootCookiesCache', {});
+    let fastBootCache = this._fastBootCookiesCache || {};
     let cachedOptions = merge({}, options);
 
     if (cachedOptions.maxAge) {
@@ -138,7 +138,7 @@ export default Service.extend({
     }
 
     fastBootCache[name] = { value, options: cachedOptions };
-    this.set('_fastBootCookiesCache', fastBootCache);
+    this._fastBootCookiesCache = fastBootCache;
   },
 
   _filterCachedFastBootCookies(fastBootCookiesCache) {

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -38,19 +38,18 @@ export default Service.extend({
   }).volatile(),
 
   _fastBootCookies: computed(function() {
-    let fastBootCookiesCache = this._fastBootCookiesCache;
+    let fastBootCookies = this.get('_fastBoot.request.cookies');
+    fastBootCookies = A(keys(fastBootCookies)).reduce((acc, name) => {
+      let value = fastBootCookies[name];
+      acc[name] = { value };
+      return acc;
+    }, {});
 
-    if (!fastBootCookiesCache) {
-      let fastBootCookies = this.get('_fastBoot.request.cookies');
-      fastBootCookiesCache = A(keys(fastBootCookies)).reduce((acc, name) => {
-        let value = fastBootCookies[name];
-        acc[name] = { value };
-        return acc;
-      }, {});
-      this._fastBootCookiesCache = fastBootCookiesCache;
-    }
+    let fastBootCookiesCache = this._fastBootCookiesCache || {};
+    fastBootCookies = assign({}, fastBootCookies, fastBootCookiesCache);
+    this._fastBootCookiesCache = fastBootCookies;
 
-    return this._filterCachedFastBootCookies(fastBootCookiesCache);
+    return this._filterCachedFastBootCookies(fastBootCookies);
   }).volatile(),
 
   read(name, options = {}) {
@@ -141,14 +140,14 @@ export default Service.extend({
     this._fastBootCookiesCache = fastBootCache;
   },
 
-  _filterCachedFastBootCookies(fastBootCookiesCache) {
+  _filterCachedFastBootCookies(fastBootCookies) {
     let { path: requestPath, protocol } = this.get('_fastBoot.request');
 
     // cannot use deconstruct here
     let host = this.get('_fastBoot.request.host');
 
-    return A(keys(fastBootCookiesCache)).reduce((acc, name) => {
-      let { value, options } = fastBootCookiesCache[name];
+    return A(keys(fastBootCookies)).reduce((acc, name) => {
+      let { value, options } = fastBootCookies[name];
       options = options || {};
 
       let { path: optionsPath, domain, expires, secure } = options;

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -572,6 +572,15 @@ describe('CookiesService', function() {
 
         expect(this.subject().read(COOKIE_NAME)).to.eq(value);
       });
+
+      it('respects the request headers after a cookie was written already', function() {
+        let writtenValue = randomString();
+        this.subject().write(COOKIE_NAME, writtenValue);
+        let requestValue = randomString();
+        this.fakeFastBoot.request.cookies = { aRequestCookie: requestValue };
+
+        expect(this.subject().read()).to.deep.equal({ [COOKIE_NAME]: writtenValue, aRequestCookie: requestValue });
+      });
     });
 
     describe('writing a cookie', function() {


### PR DESCRIPTION
This fixes the FastBoot cookie caching logic so that we always read the request cookies now and merge them with the cache. Previously, when the cache was already populated, we would never read the request cookies again. As the cache is also populated when cookies are written (which is the main reason we need the cache as we cannot read written cookies again from anywhere), it was possible to run into a situation where the cache was populated by a write before anything had ever be read and then on the next read, the request cookies would be ignored (@joshkg describes that much better in #177).

closes #177 