### PR TITLE
Allow setting httpOnly

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -73,7 +73,6 @@ export default Service.extend({
 
   write(name, value, options = {}) {
     options = assign({}, DEFAULTS, options || {});
-    assert('Cookies cannot be set to be HTTP-only as those cookies would not be accessible by the Ember.js application itself when running in the browser!', !options.httpOnly);
     assert("Cookies cannot be set as signed as signed cookies would not be modifyable in the browser as it has no knowledge of the express server's signing key!", !options.signed);
     assert('Cookies cannot be set with both maxAge and an explicit expiration time!', isEmpty(options.expires) || isEmpty(options.maxAge));
 
@@ -84,6 +83,7 @@ export default Service.extend({
     if (this.get('_isFastBoot')) {
       this._writeFastBootCookie(name, value, options);
     } else {
+      assert('Cookies cannot be set to be HTTP-only from a browser!', !options.httpOnly);
       this._writeDocumentCookie(name, value, options);
     }
   },
@@ -210,6 +210,9 @@ export default Service.extend({
     }
     if (options.secure) {
       cookie = `${cookie}; secure`;
+    }
+    if (options.httpOnly) {
+      cookie = `${cookie}; httpOnly`;
     }
     if (!isEmpty(options.path)) {
       cookie = `${cookie}; path=${options.path}`;

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -23,12 +23,6 @@ describe('CookiesService', function() {
       }).to.throw();
     });
 
-    it('throws when the HTTP only option is set', function() {
-      expect(() => {
-        this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
-      }).to.throw();
-    });
-
     it('throws when both the expires and max age options are set', function() {
       expect(() => {
         this.subject().write(COOKIE_NAME, 'test', { expires: new Date(), maxAge: 1000 });
@@ -314,6 +308,11 @@ describe('CookiesService', function() {
         }).to.throw();
       });
 
+      it('throws when using the httpOnly option', function() {
+        expect(() => {
+          this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
+        }).to.throw();
+      });
     });
 
     describe('clearing a cookie', function() {
@@ -672,6 +671,21 @@ describe('CookiesService', function() {
         };
 
         this.subject().write(COOKIE_NAME, 'test', { path });
+      });
+
+      it('sets the httpOnly flag', function() {
+        this.fakeFastBoot.response.headers.append = function(headerName, headerValue) {
+          expect(headerName).to.equal('set-cookie');
+          expect(headerValue).to.equal(`${COOKIE_NAME}=test; httpOnly`);
+        };
+
+        this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
+      });
+
+      it('allows the httpOnly option', function() {
+        expect(() => {
+          this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
+        }).to.not.throw();
       });
     });
 


### PR DESCRIPTION
There is currently no support for setting `httpOnly` on cookies in `write()`, with an explicit assert saying it's not useful.

While what it says is true and you won't be able to read them from inside Ember, there are still useful reasons you might want to set a httpOnly cookie, e.g. if it is generated by the client but only needs to be readable by a backend service/API.

(If you prefer to keep the assert, it could instead be an option like `yesReallyHttpOnly` passed into `write()` that causes it to allow writing one, I just need _some_ way to do it)