### PR TITLE
Send a given cookie name only once per fastboot response

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -122,7 +122,20 @@ export default Service.extend({
 
     this._cacheFastBootCookie(...arguments);
 
-    responseHeaders.append('set-cookie', serializedCookie);
+    let replaced = false;
+    let existing = responseHeaders.getAll('set-cookie');
+
+    for (let i = 0; i < existing.length; i++) {
+      if (existing[i].startsWith(`${name}=`)) {
+        existing[i] = serializedCookie;
+        replaced = true;
+        break;
+      }
+    }
+
+    if (!replaced) {
+      responseHeaders.append('set-cookie', serializedCookie);
+    }
   },
 
   _cacheFastBootCookie(name, value, options = {}) {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -437,10 +437,23 @@ describe('CookiesService', function() {
         })
       });
 
+      const responseHeaders = {};
+
       this.fakeFastBoot = {
         response: {
           headers: {
-            append() {}
+            getAll(name) {
+              if (name) {
+                return responseHeaders[name] || [];
+              } else {
+                return responseHeaders;
+              }
+            },
+            append(name, value) {
+              let entry = responseHeaders[name] || [];
+              responseHeaders[name] = entry;
+              entry.push(value);
+            }
           }
         },
         request: request.create()
@@ -595,6 +608,19 @@ describe('CookiesService', function() {
         };
 
         this.subject().write(COOKIE_NAME, value);
+      });
+
+      it('writes the same name only once', function() {
+        let value1 = randomString();
+        let value2 = randomString();
+
+        this.subject().write(COOKIE_NAME, value1);
+        this.subject().write(COOKIE_NAME, value2);
+
+        const headers = this.fakeFastBoot.response.headers.getAll('set-cookie');
+        expect(headers.length).to.equal(1);
+        expect(headers[0]).to.not.equal(`${COOKIE_NAME}=${value1}`);
+        expect(headers[0]).to.equal(`${COOKIE_NAME}=${value2}`);
       });
 
       it('URI-component-encodes the value', function() {


### PR DESCRIPTION
Currently, every time something calls write() a new Set-Cookie header gets added for fastboot. So if you do:

```
cookies.write('foo', 'value1');
cookies.write('foo', 'value2');
```

The response headers are sent as:

```
Set-Cookie: foo=value1
Set-Cookie: foo=value2
```

And all that is sent in the response back to the client/browser, which then ignores all but the last set for a given key.  ember-simple-auth in particular does several sets of the same key and ends up constantly sending multiple values for the same cookie.

This PR changes `write()` -> `_writeFastBootCookie(name, value)` to look for an existing `set-cookie` header for `name` and replace the existing entry's value with the new one if found, instead of always appending a new entry.