### PR TITLE
Fixes #206 fix ember-polyfills.deprecate-merge deprecation

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -5,9 +5,9 @@ import { assert } from '@ember/debug';
 import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
 import Service from '@ember/service';
-import { merge, assign as emberAssign } from '@ember/polyfills';
+import { assign as emberAssign } from '@ember/polyfills';
 const { keys } = Object;
-const assign = Object.assign || emberAssign || merge;
+const assign = Object.assign || emberAssign;
 const DEFAULTS = { raw: false };
 const MAX_COOKIE_BYTE_LENGTH = 4096;
 


### PR DESCRIPTION
Fixes the deprecation:
```
DEPRECATION: Use of `merge` has been deprecated. Please use `assign` instead. [deprecation id: ember-polyfills.deprecate-merge] See https://emberjs.com/deprecations/v3.x/#toc_ember-polyfills-deprecate-merge for more details.
```