### PR TITLE
move test for test helper into own test file

### DIFF
--- a/tests/unit/clear-all-cookies-test.js
+++ b/tests/unit/clear-all-cookies-test.js
@@ -1,0 +1,22 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import clearAllCookies from 'ember-cookies/clear-all-cookies';
+
+function randomString() {
+  return Math.random().toString(36).substring(2);
+}
+
+describe('clearAllCookies test helper', function() {
+  it('clears all cookies', function() {
+    let value1 = randomString();
+    let value2 = randomString();
+    document.cookie = `test1=${value1};`;
+    document.cookie = `test2=${value2};`;
+
+    clearAllCookies();
+
+    expect(document.cookie).to.not.include(`test1=${value1};`);
+    expect(document.cookie).to.not.include(`test2=${value2};`);
+  });
+});

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -4,7 +4,6 @@ import EmberOject, { computed } from '@ember/object';
 import { expect } from 'chai';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import clearAllCookies from 'ember-cookies/clear-all-cookies';
 const { defineProperty } = Object;
 
 const COOKIE_NAME = 'test-cookie';
@@ -388,21 +387,6 @@ describe('CookiesService', function() {
 
           expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
         });
-      });
-    });
-
-    describe('clearing all cookies with test helper', function() {
-      it('clears all cookies', function() {
-        document.cookie = `test1=${randomString()};`;
-        document.cookie = `test2=${randomString()};`;
-
-        expect(this.subject().read('test1')).not.to.be.empty;
-        expect(this.subject().read('test2')).not.to.be.empty;
-
-        clearAllCookies();
-
-        expect(this.subject().read('test1')).to.be.empty;
-        expect(this.subject().read('test2')).to.be.empty;
       });
     });
 


### PR DESCRIPTION
This moves the tests for the `clearAllCookies` test helper into their own test file instead of testing the helper in the unit test of the `cookies` service.