### PR TITLE
Fixing Deprecation for older versions of Ember

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.1.0",
-    "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+    "ember-getowner-polyfill": "^2.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
I'm upgrading to the current LTS version of Ember, and 1.1.0 contains deprecations