### PR TITLE
Add SameSite attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ The `cookies` service has methods for reading and writing cookies:
   URL-decoding the value).
 * `write(name, value, options = {})`: writes a cookie with the given name and
   value; options can be used to set `domain`, `expires` (Date), `maxAge` (time
-  in seconds), `path`, `secure`, and `raw` (boolean, disables URL-encoding the
-  value).
+  in seconds), `path`, `secure`, `raw` (boolean, disables URL-encoding the
+  value) and `sameSite` (can be either `'strict'` or `'lax'`).
 * `clear(name, options = {})`: clears the cookie so that future reads do not
   return a value; options can be used to specify `domain`, `path` or `secure`.
 * `exists(name)`: checks whether a cookie exists at all (even with a falsy

--- a/addon/utils/serialize-cookie.js
+++ b/addon/utils/serialize-cookie.js
@@ -21,6 +21,9 @@ export const serializeCookie = (name, value, options = {}) => {
   if (!isEmpty(options.path)) {
     cookie = `${cookie}; path=${options.path}`;
   }
+  if (!isEmpty(options.sameSite)) {
+    cookie = `${cookie}; SameSite=${options.sameSite}`;
+  }
 
   return cookie;
 };

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -328,6 +328,16 @@ describe('CookiesService', function() {
           this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
         }).to.throw();
       });
+
+      it('sets the sameSite flag', function() {
+        defineProperty(this.fakeDocument, 'cookie', {
+          set(value) {
+            expect(value).to.include('; SameSite=Strict');
+          }
+        });
+
+        this.subject().write(COOKIE_NAME, 'test', { sameSite: 'Strict' });
+      });
     });
 
     describe('clearing a cookie', function() {

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -723,6 +723,15 @@ describe('CookiesService', function() {
           this.subject().write(COOKIE_NAME, 'test', { httpOnly: true });
         }).to.not.throw();
       });
+
+      it('sets the sameSite flag', function() {
+        this.fakeFastBoot.response.headers.append = function(headerName, headerValue) {
+          expect(headerName).to.equal('set-cookie');
+          expect(headerValue).to.equal(`${COOKIE_NAME}=test; SameSite=Strict`);
+        };
+
+        this.subject().write(COOKIE_NAME, 'test', { sameSite: 'Strict' });
+      });
     });
 
     describe('clearing a cookie', function() {


### PR DESCRIPTION
There is a new cookie attribute called SameSite that we may want to support as well.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
```
`SameSite=Strict`
`SameSite=Lax` (Optional)
Allows servers to assert that a cookie ought not to be sent along with cross-site requests, which provides some protection against cross-site request forgery attacks (CSRF).
```