### PR TITLE
Remove unnecessary cruft

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -1,6 +1,5 @@
 import { isNone, isPresent, isEmpty } from '@ember/utils';
 import { assert } from '@ember/debug';
-import { A } from '@ember/array';
 import { getOwner } from '@ember/application';
 import Service from '@ember/service';
 import { merge, assign as emberAssign } from '@ember/polyfills';
@@ -24,7 +23,7 @@ export default Service.extend({
 
   _getDocumentCookies() {
     let all = this._document.cookie.split(';');
-    let filtered = this._filterDocumentCookies(A(all));
+    let filtered = this._filterDocumentCookies(all);
 
     return filtered.reduce((acc, cookie) => {
       if (!isEmpty(cookie)) {
@@ -37,7 +36,7 @@ export default Service.extend({
 
   _getFastBootCookies() {
     let fastBootCookies = this._fastBoot.request.cookies;
-    fastBootCookies = A(keys(fastBootCookies)).reduce((acc, name) => {
+    fastBootCookies = keys(fastBootCookies).reduce((acc, name) => {
       let value = fastBootCookies[name];
       acc[name] = { value };
       return acc;
@@ -64,7 +63,7 @@ export default Service.extend({
     if (name) {
       return this._decodeValue(all[name], options.raw);
     } else {
-      A(keys(all)).forEach((name) => (all[name] = this._decodeValue(all[name], options.raw)));
+      keys(all).forEach((name) => (all[name] = this._decodeValue(all[name], options.raw)));
       return all;
     }
   },
@@ -160,7 +159,7 @@ export default Service.extend({
     // cannot use deconstruct here
     let host = this._fastBoot.request.host;
 
-    return A(keys(fastBootCookies)).reduce((acc, name) => {
+    return keys(fastBootCookies).reduce((acc, name) => {
       let { value, options } = fastBootCookies[name];
       options = options || {};
 

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -1,5 +1,3 @@
-import { computed } from '@ember/object';
-import { reads } from '@ember/object/computed';
 import { isNone, isPresent, isEmpty } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { A } from '@ember/array';
@@ -13,20 +11,19 @@ const DEFAULTS = { raw: false };
 const MAX_COOKIE_BYTE_LENGTH = 4096;
 
 export default Service.extend({
-  _isFastBoot: reads('_fastBoot.isFastBoot'),
+  init() {
+    this._super(...arguments);
 
-  _fastBoot: computed(function() {
-    let owner = getOwner(this);
+    this._document = this._document || window.document;
+    if (typeof this._fastBoot === 'undefined') {
+      let owner = getOwner(this);
 
-    return owner.lookup('service:fastboot');
-  }),
-
-  _document: computed(function() {
-    return document;
-  }),
+      this._fastBoot = owner.lookup('service:fastboot');
+    }
+  },
 
   _getDocumentCookies() {
-    let all = this.get('_document.cookie').split(';');
+    let all = this._document.cookie.split(';');
     let filtered = this._filterDocumentCookies(A(all));
 
     return filtered.reduce((acc, cookie) => {
@@ -39,7 +36,7 @@ export default Service.extend({
   },
 
   _getFastBootCookies() {
-    let fastBootCookies = this.get('_fastBoot.request.cookies');
+    let fastBootCookies = this._fastBoot.request.cookies;
     fastBootCookies = A(keys(fastBootCookies)).reduce((acc, name) => {
       let value = fastBootCookies[name];
       acc[name] = { value };
@@ -58,7 +55,7 @@ export default Service.extend({
     assert('Domain, Expires, Max-Age, and Path options cannot be set when reading cookies', isEmpty(options.domain) && isEmpty(options.expires) && isEmpty(options.maxAge) && isEmpty(options.path));
 
     let all;
-    if (this.get('_isFastBoot')) {
+    if (this._fastBoot.isFastBoot) {
       all = this._getFastBootCookies();
     } else {
       all = this._getDocumentCookies();
@@ -81,7 +78,7 @@ export default Service.extend({
 
     assert(`Cookies larger than ${MAX_COOKIE_BYTE_LENGTH} bytes are not supported by most browsers!`, this._isCookieSizeAcceptable(value));
 
-    if (this.get('_isFastBoot')) {
+    if (this._fastBoot.isFastBoot) {
       this._writeFastBootCookie(name, value, options);
     } else {
       assert('Cookies cannot be set to be HTTP-only from a browser!', !options.httpOnly);
@@ -102,7 +99,7 @@ export default Service.extend({
 
   exists(name) {
     let all;
-    if (this.get('_isFastBoot')) {
+    if (this._fastBoot.isFastBoot) {
       all = this._getFastBootCookies();
     } else {
       all = this._getDocumentCookies();
@@ -113,11 +110,11 @@ export default Service.extend({
 
   _writeDocumentCookie(name, value, options = {}) {
     let serializedCookie = this._serializeCookie(name, value, options);
-    this.set('_document.cookie', serializedCookie);
+    this._document.cookie = serializedCookie;
   },
 
   _writeFastBootCookie(name, value, options = {}) {
-    let responseHeaders = this.get('_fastBoot.response.headers');
+    let responseHeaders = this._fastBoot.response.headers;
     let serializedCookie = this._serializeCookie(...arguments);
 
     if (!isEmpty(options.maxAge)) {
@@ -158,10 +155,10 @@ export default Service.extend({
   },
 
   _filterCachedFastBootCookies(fastBootCookies) {
-    let { path: requestPath, protocol } = this.get('_fastBoot.request');
+    let { path: requestPath, protocol } = this._fastBoot.request;
 
     // cannot use deconstruct here
-    let host = this.get('_fastBoot.request.host');
+    let host = this._fastBoot.request.host;
 
     return A(keys(fastBootCookies)).reduce((acc, name) => {
       let { value, options } = fastBootCookies[name];
@@ -238,7 +235,7 @@ export default Service.extend({
   },
 
   _normalizedDefaultPath() {
-    if (!this.get('_isFastBoot')) {
+    if (!this._fastBoot.isFastBoot) {
       let pathname = window.location.pathname;
       return pathname.substring(0, pathname.lastIndexOf('/'));
     }

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -86,6 +86,9 @@ describe('CookiesService', function() {
 
   describe('in the browser', function() {
     beforeEach(function() {
+      this.fakeFastBoot = {
+        isFastBoot: false,
+      };
       this.fakeDocument = {
         // jscs:disable requireEnhancedObjectLiterals
         get cookie() {
@@ -96,7 +99,8 @@ describe('CookiesService', function() {
         }
         // jscs:enable requireEnhancedObjectLiterals
       };
-      this.subject().set('_document', this.fakeDocument);
+      this.subject()._document = this.fakeDocument;
+      this.subject()._fastBoot = this.fakeFastBoot;
     });
 
     afterEach(function() {
@@ -437,6 +441,7 @@ describe('CookiesService', function() {
       const responseHeaders = {};
 
       this.fakeFastBoot = {
+        isFastBoot: true,
         response: {
           headers: {
             getAll(name) {
@@ -456,7 +461,6 @@ describe('CookiesService', function() {
         request: request.create()
       };
       this.subject().setProperties({
-        _isFastBoot: true,
         _fastBoot: this.fakeFastBoot
       });
     });


### PR DESCRIPTION
This removes unnecessary cruft and thus simplifies the codebase:

* private computed properties in the `cookies` service are converted to regular properties
* arrays that were unnecessarily wrapped in  Ember.Array are now regular arrays