### PR TITLE
Fix travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ jobs:
       env: EMBER_TRY_SCENARIO=ember-1.13
     - env: EMBER_TRY_SCENARIO=ember-lts-2.4
     - env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-3.0
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,28 @@ cache:
   directories:
     - $HOME/.cache
 
-env:
-  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-default
+jobs:
+  fail_fast: true
+  include:
+    - stage: 'Tests'
+      env: EMBER_TRY_SCENARIO=ember-1.13
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-release
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-default
+
+    - stage: 'Deploy'
+      if: tag IS present
+      script: skip     # usually you do not want to rerun any tests
+      deploy:
+        provider: npm
+        email: info@simplabs.com
+        api_key:
+          secure: PA0X+4BPH2ACTKsOJQ5/018XKB6OZ3jUR5le/8ILCIfsCJUTSe1qKjv2qu10fhRDsUd1/HXSiqDWk4xnbencrkK5QhYkpR+6r2ryu01yGXqy3sKHxSZRdy7to0XHMUY55l5avvZPCUOohQljdEqb2zksSP26AfIDq3hXmqjvLaKyN/rV7KzG5X+a77WO0BMXefogBGA5HV8o7irKNMaU04z5XoKvzqJoVH9Mjc58YPLtC/8BYIO0dpkBiAxdEkz1pioha1SRgtQEhvfcK+8xoo+iCMglx6FvbuHI4GRHLgBGYfBDzuebqCgKgY1oiMLVoZpzhFs/qLpUGsZMZLkGQD0OPDidrnDPHaGERJIu/GC5lPuyRAtIYSfTJCT93Y30ZyHSJwgDEu4x4wO3Xy+3uXqo1y1kx8DE2moDFhrxeDlTZTQdt1+HDmwTFwLn9iZHngJLU5Yzf+5dGV3eREig0pjyBSBKK1a2jZO/YOxUYeYUkDxRjon6DyGMwi+DP59HHsr23Shntt70lUrmyBJTfBo1OQDB0OzeyLN7n+Q/ybpFqO58uVRE2w+eGepm9pDWeb1uWX+tSvBc7PTBdE+8aAQkUDfCEIZ916Oq4ijpkW/Bt83LncxmLb9Sd8/UKyG0ozkZgvgTqbJaRQef9IewYv9tfsneDqYsSdDHSwUfQDw=
+        on:
+          repo: simplabs/ember-cookies
 
 matrix:
   fast_finish: true
@@ -40,15 +53,6 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
-
-deploy:
-  provider: npm
-  email: info@simplabs.com
-  api_key:
-    secure: PA0X+4BPH2ACTKsOJQ5/018XKB6OZ3jUR5le/8ILCIfsCJUTSe1qKjv2qu10fhRDsUd1/HXSiqDWk4xnbencrkK5QhYkpR+6r2ryu01yGXqy3sKHxSZRdy7to0XHMUY55l5avvZPCUOohQljdEqb2zksSP26AfIDq3hXmqjvLaKyN/rV7KzG5X+a77WO0BMXefogBGA5HV8o7irKNMaU04z5XoKvzqJoVH9Mjc58YPLtC/8BYIO0dpkBiAxdEkz1pioha1SRgtQEhvfcK+8xoo+iCMglx6FvbuHI4GRHLgBGYfBDzuebqCgKgY1oiMLVoZpzhFs/qLpUGsZMZLkGQD0OPDidrnDPHaGERJIu/GC5lPuyRAtIYSfTJCT93Y30ZyHSJwgDEu4x4wO3Xy+3uXqo1y1kx8DE2moDFhrxeDlTZTQdt1+HDmwTFwLn9iZHngJLU5Yzf+5dGV3eREig0pjyBSBKK1a2jZO/YOxUYeYUkDxRjon6DyGMwi+DP59HHsr23Shntt70lUrmyBJTfBo1OQDB0OzeyLN7n+Q/ybpFqO58uVRE2w+eGepm9pDWeb1uWX+tSvBc7PTBdE+8aAQkUDfCEIZ916Oq4ijpkW/Bt83LncxmLb9Sd8/UKyG0ozkZgvgTqbJaRQef9IewYv9tfsneDqYsSdDHSwUfQDw=
-  on:
-    tags: true
-    repo: simplabs/ember-cookies
 
 notifications:
   email: false

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,109 +1,256 @@
 /* eslint-env node */
 
-module.exports = {
-  useYarn: true,
-  scenarios: [
-    {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
+const getChannelURL = require('ember-source-channel-url');
+
+module.exports = function() {
+  return Promise.all([
+    getChannelURL('release'),
+    getChannelURL('beta'),
+    getChannelURL('canary')
+  ]).then(urls => {
+    const releaseUrl = urls[0];
+    const betaUrl = urls[1];
+    const canaryUrl = urls[2];
+    return {
+      useYarn: true,
+      scenarios: [
+        {
+          name: 'ember-1.13',
+          bower: {
+            dependencies: {
+              ember: '~1.13.0',
+              'ember-cli-shims': '0.0.6',
+              'ember-data': '~1.13.0',
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-cli-shims': null,
+              'ember-data': '~1.13.0',
+              'ember-source': null,
+            },
+          },
         },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
+        {
+          name: 'ember-2.0',
+          bower: {
+            dependencies: {
+              ember: '~2.0.0',
+              'ember-cli-shims': '0.0.6',
+              'ember-data': '~2.0.0',
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-cli-shims': null,
+              'ember-data': '~2.0.0',
+              'ember-source': null,
+            },
+          },
         },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
+        {
+          name: 'ember-lts-2.4',
+          bower: {
+            dependencies: {
+              ember: 'components/ember#lts-2-4',
+              'ember-cli-shims': '0.1.0',
+              'ember-data': null,
+            },
+            resolutions: {
+              ember: 'lts-2-4',
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-cli-shims': null,
+              'ember-data': '~2.4.0',
+              'ember-source': null,
+            },
+          },
         },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
+        {
+          name: 'ember-lts-2.8',
+          bower: {
+            dependencies: {
+              ember: 'components/ember#lts-2-8',
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+            resolutions: {
+              ember: 'lts-2-8',
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~2.8.0',
+              'ember-source': null,
+            },
+          },
         },
-        resolutions: {
-          'ember': 'release'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
+        {
+          name: 'ember-lts-2.12',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~2.12.0',
+              'ember-source': '~2.12.0',
+            },
+          },
         },
-        resolutions: {
-          'ember': 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
+        {
+          name: 'ember-lts-2.16',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~2.16.0',
+              'ember-source': '~2.16.0',
+            },
+          },
         },
-        resolutions: {
-          'ember': 'canary'
+        {
+          name: 'ember-lts-2.18',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~2.18.0',
+              'ember-source': '~2.18.0',
+            },
+          },
+        },
+        {
+          name: 'ember-3.0',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.0.0',
+              'ember-source': '~3.0.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.4',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.4.0',
+              'ember-source': '~3.4.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.8',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.8.0',
+              'ember-source': '~3.8.0',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-3.12',
+          bower: {
+            dependencies: {
+              ember: null,
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.12.0',
+              'ember-source': '~3.12.0',
+            },
+          },
+        },
+        {
+          name: 'ember-release',
+          bower: {
+            dependencies: {
+              'ember-cli-shims': null,
+              'ember-data': null,
+            }
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': 'latest',
+              'ember-source': releaseUrl,
+            },
+          },
+        },
+        {
+          name: 'ember-beta',
+          bower: {
+            dependencies: {
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': 'beta',
+              'ember-source': betaUrl,
+            },
+          },
+        },
+        {
+          name: 'ember-canary',
+          bower: {
+            dependencies: {
+              'ember-cli-shims': null,
+              'ember-data': null,
+            },
+          },
+          npm: {
+            devDependencies: {
+              'ember-data': 'canary',
+              'ember-source': canaryUrl,
+            },
+          },
+        },
+        {
+          name: 'ember-default',
+          npm: {
+            devDependencies: {}
+          }
         }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      },
-    },
-    {
-      name: 'ember-default',
-      npm: {
-        devDependencies: {}
-      },
-    }
-  ]
+      ]
+    };
+  });
 };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-resolver": "^5.1.3",
     "ember-sinon": "4.1.1",
     "ember-source": "~3.13.2",
+    "ember-source-channel-url": "^2.0.1",
     "ember-try": "^1.1.0",
     "eslint-config-simplabs": "0.4.0",
     "eslint-plugin-ember": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3493,6 +3493,7 @@ ember-source-channel-url@^1.0.1:
 ember-source-channel-url@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-source-channel-url/-/ember-source-channel-url-2.0.1.tgz#18b88f8a00b7746e7a456b3551abb3aea18729cc"
+  integrity sha512-YlLUHW9gNvxEaohIj5exykoTZb4xj9ZRTcR4J3svv9S8rjAHJUnHmqC5Fd9onCs+NGxHo7KwR/fDwsfadbDu5Q==
   dependencies:
     got "^8.0.1"
 


### PR DESCRIPTION
This fixes 2 problems with the Travis pipeline:

* currently, the deployment step runs for **all** environments which means we're deploying several times (which is likely not a huge problem as it's the same version each time anyway and subsequent deployments will fail anyways because of that) but we're also deploying if 1 test environment completes successfully while we actually want to wait for all of them; this moves the deployment to a separate stage that will only run once **all** test environments have succeeded
* we are currently only testing against the LTS releases from Ember's 2.x series; this adds the LTS releases from the 3.x series as well