### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
+/.node_modules.ember-try
 /bower_components
 /config/ember-try.js
 /dist
+/node-tests
 /tests
 /tmp
 **/.gitkeep


### PR DESCRIPTION
Folder `.node_modules.ember-try` accidentally got published in npm package.

Folder `node-tests` does not seem need to be published as well.