### PR TITLE
Remove wrong implementation of secure attribute

### DIFF
--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -155,7 +155,7 @@ export default Service.extend({
   },
 
   _filterCachedFastBootCookies(fastBootCookies) {
-    let { path: requestPath, protocol } = get(this._fastBoot, 'request');
+    let { path: requestPath } = get(this._fastBoot, 'request');
 
     // cannot use deconstruct here
     let host = get(this._fastBoot, 'request.host');
@@ -164,7 +164,7 @@ export default Service.extend({
       let { value, options } = fastBootCookies[name];
       options = options || {};
 
-      let { path: optionsPath, domain, expires, secure } = options;
+      let { path: optionsPath, domain, expires } = options;
 
       if (optionsPath && requestPath.indexOf(optionsPath) !== 0) {
         return acc;
@@ -175,10 +175,6 @@ export default Service.extend({
       }
 
       if (expires && expires < new Date()) {
-        return acc;
-      }
-
-      if (secure && !(protocol || '').match(/^https/)) {
         return acc;
       }
 

--- a/tests/unit/services/cookies-test.js
+++ b/tests/unit/services/cookies-test.js
@@ -205,21 +205,6 @@ describe('CookiesService', function() {
           expect(this.subject().read(COOKIE_NAME)).to.eq(value);
         });
 
-        it('returns undefined for a cookie that was written for another protocol (secure cookies vs. non-secure request)', function() {
-          let isHTTPS = window.location.protocol === 'https:';
-          this.subject().write(COOKIE_NAME, 'value', { secure: !isHTTPS });
-
-          expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
-        });
-
-        it('returns the cookie value for a cookie that was written for the same protocol', function() {
-          let isHTTPS = window.location.protocol === 'https:';
-          let value = randomString();
-          this.subject().write(COOKIE_NAME, value, { secure: isHTTPS });
-
-          expect(this.subject().read(COOKIE_NAME)).to.eq(value);
-        });
-
         it('works when the cookie contains a "="', function() {
           let value = `${randomString()}=${randomString()}`;
           document.cookie = `${COOKIE_NAME}=${value};`;
@@ -586,30 +571,6 @@ describe('CookiesService', function() {
       it('returns the cookie value for a cookie that has not yet reached its max age', function() {
         let value = randomString();
         this.subject().write(COOKIE_NAME, value, { maxAge: 99999999 });
-
-        expect(this.subject().read(COOKIE_NAME)).to.eq(value);
-      });
-
-      it('returns undefined for a cookie that was written for another protocol (secure cookies vs. non-secure request)', function() {
-        this.fakeFastBoot.request._host = 'http';
-        let value = randomString();
-        this.subject().write(COOKIE_NAME, value, { secure: true });
-
-        expect(this.subject().read(COOKIE_NAME)).to.be.undefined;
-      });
-
-      it('returns the cookie value for a cookie that was written for the same protocol ("https")', function() {
-        this.fakeFastBoot.request.protocol = 'https';
-        let value = randomString();
-        this.subject().write(COOKIE_NAME, value, { secure: true });
-
-        expect(this.subject().read(COOKIE_NAME)).to.eq(value);
-      });
-
-      it('returns the cookie value for a cookie that was written for the same protocol ("https:")', function() {
-        this.fakeFastBoot.request.protocol = 'https:';
-        let value = randomString();
-        this.subject().write(COOKIE_NAME, value, { secure: true });
 
         expect(this.subject().read(COOKIE_NAME)).to.eq(value);
       });


### PR DESCRIPTION
The idea of the check was that a cookie that was written with the secure attribute should only be visible when the current location's protocol is `https:`. That is not actually correct though – according to [RFC 6265](https://tools.ietf.org/html/rfc6265#section-4.1.2.5), the `secure` attribute only controls whether the cookie is sent with secure (HTTPS) requests only or not which does not mean it cannot be accessible from non-secure locations. Chrome's behavior is different from Firefox' here but that's a matter of these browsers and not something we need to cover in the tests. The PR also removes the (wrong) implementation of the same mechanism from the FastBoot part of the addon (where a cookie with the secure flag was only visible when the request's protocol is `https:`).