### PR TITLE
Drop support for Ember versions < 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,12 @@ jobs:
     strategy:
       matrix:
         test-suite:
-          - ember-1.13
-          - ember-lts-2.4
-          - ember-lts-2.8
-          - ember-3.0
           - ember-3.0
           - ember-lts-3.4
           - ember-lts-3.8
           - ember-lts-3.12
+          - ember-lts-3.16
+          - ember-lts-3.20
           - ember-release
           - ember-beta
           - ember-canary

--- a/addon-test-support/ember-cookies/clear-all-cookies.js
+++ b/addon-test-support/ember-cookies/clear-all-cookies.js
@@ -1,8 +1,8 @@
 import { assert } from '@ember/debug';
-import { merge, assign as emberAssign } from '@ember/polyfills';
+import { assign as emberAssign } from '@ember/polyfills';
 import { isEmpty } from '@ember/utils';
 import { serializeCookie } from 'ember-cookies/utils/serialize-cookie';
-const assign = Object.assign || emberAssign || merge;
+const assign = Object.assign || emberAssign;
 
 export default function(options = {}) {
   assert('Cookies cannot be set to be HTTP-only from a browser!', !options.httpOnly);

--- a/addon/services/cookies.js
+++ b/addon/services/cookies.js
@@ -3,10 +3,10 @@ import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import Service from '@ember/service';
-import { merge, assign as emberAssign } from '@ember/polyfills';
+import { assign as emberAssign } from '@ember/polyfills';
 import { serializeCookie } from '../utils/serialize-cookie';
 const { keys } = Object;
-const assign = Object.assign || emberAssign || merge;
+const assign = Object.assign || emberAssign;
 const DEFAULTS = { raw: false };
 const MAX_COOKIE_BYTE_LENGTH = 4096;
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,135 +15,7 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-1.13',
-          bower: {
-            dependencies: {
-              ember: '~1.13.0',
-              'ember-cli-shims': '0.0.6',
-              'ember-data': '~1.13.0',
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-cli-shims': null,
-              'ember-data': '~1.13.0',
-              'ember-source': null,
-            },
-          },
-        },
-        {
-          name: 'ember-2.0',
-          bower: {
-            dependencies: {
-              ember: '~2.0.0',
-              'ember-cli-shims': '0.0.6',
-              'ember-data': '~2.0.0',
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-cli-shims': null,
-              'ember-data': '~2.0.0',
-              'ember-source': null,
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.4',
-          bower: {
-            dependencies: {
-              ember: 'components/ember#lts-2-4',
-              'ember-cli-shims': '0.1.0',
-              'ember-data': null,
-            },
-            resolutions: {
-              ember: 'lts-2-4',
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-cli-shims': null,
-              'ember-data': '~2.4.0',
-              'ember-source': null,
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.8',
-          bower: {
-            dependencies: {
-              ember: 'components/ember#lts-2-8',
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-            resolutions: {
-              ember: 'lts-2-8',
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-data': '~2.8.0',
-              'ember-source': null,
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.12',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-data': '~2.12.0',
-              'ember-source': '~2.12.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.16',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-data': '~2.16.0',
-              'ember-source': '~2.16.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.18',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
-          npm: {
-            devDependencies: {
-              'ember-data': '~2.18.0',
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
           name: 'ember-3.0',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': '~3.0.0',
@@ -153,13 +25,6 @@ module.exports = function() {
         },
         {
           name: 'ember-lts-3.4',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': '~3.4.0',
@@ -169,13 +34,6 @@ module.exports = function() {
         },
         {
           name: 'ember-lts-3.8',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': '~3.8.0',
@@ -185,13 +43,6 @@ module.exports = function() {
         },
         {
           name: 'ember-lts-3.12',
-          bower: {
-            dependencies: {
-              ember: null,
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': '~3.12.0',
@@ -200,13 +51,25 @@ module.exports = function() {
           },
         },
         {
-          name: 'ember-release',
-          bower: {
-            dependencies: {
-              'ember-cli-shims': null,
-              'ember-data': null,
-            }
+          name: 'ember-lts-3.16',
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.16.0',
+              'ember-source': '~3.16.0',
+            },
           },
+        },
+        {
+          name: 'ember-lts-3.20',
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.20.0',
+              'ember-source': '~3.20.0',
+            },
+          },
+        },
+        {
+          name: 'ember-release',
           npm: {
             devDependencies: {
               'ember-data': 'latest',
@@ -216,12 +79,6 @@ module.exports = function() {
         },
         {
           name: 'ember-beta',
-          bower: {
-            dependencies: {
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': 'beta',
@@ -231,12 +88,6 @@ module.exports = function() {
         },
         {
           name: 'ember-canary',
-          bower: {
-            dependencies: {
-              'ember-cli-shims': null,
-              'ember-data': null,
-            },
-          },
           npm: {
             devDependencies: {
               'ember-data': 'canary',

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "test:one": "ember try:one"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.1.0",
-    "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+    "ember-cli-babel": "^7.1.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
     "symlink-or-copy": "^1.1.8"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "10.* || >= 12.*",
+    "versionCompatibility": {
+      "ember": ">=3.0"
+    }
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,7 +3968,7 @@ ember-cli-version-checker@^1.2.0:
   dependencies:
     semver "^5.3.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
   dependencies:
@@ -4098,20 +4098,6 @@ ember-cli@~3.20.0:
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
-
-ember-factory-for-polyfill@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-
-"ember-getowner-polyfill@^1.1.0 || ^2.0.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  integrity sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
 
 ember-load-initializers@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This drops support for Ember versions < 3.0. It also removes the now unnecessary `ember-getowner-polyfill` and always uses `Object.assign` or Ember's `assign` instead of Ember's `merge` which has been deprecated.