### PR TITLE
Remove example value for sameSite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The `cookies` service has methods for reading and writing cookies:
 * `write(name, value, options = {})`: writes a cookie with the given name and
   value; options can be used to set `domain`, `expires` (Date), `maxAge` (time
   in seconds), `path`, `secure`, `raw` (boolean, disables URL-encoding the
-  value) and `sameSite` (can be either `'strict'` or `'lax'`).
+  value) and `sameSite`.
 * `clear(name, options = {})`: clears the cookie so that future reads do not
   return a value; options can be used to specify `domain`, `path` or `secure`.
 * `exists(name)`: checks whether a cookie exists at all (even with a falsy


### PR DESCRIPTION
We're currently listing `strict` and `lax` as supported values for the `sameSite` option although we don't actually check whether the passed in value is one of those two. Like that, the documentation is not helpful and people will have to go elsewhere to learn what the two values mean anyway. Now, there's also `SameSite=None` which we already support but the README says we don't.

Hence, simply removing the docs seems the best option.

closes #381 