### PR TITLE
Update `testem` config

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,35 +1,26 @@
-/* eslint-env node */
+'use strict';
 
 module.exports = {
-  framework: 'mocha',
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: [
-    'Chrome',
-    'Firefox'
-  ],
-  launch_in_dev: [
-    'Chrome',
-    'Firefox'
-  ],
+  launch_in_ci: ['Chrome', 'Firefox'],
+  launch_in_dev: ['Chrome', 'Firefox'],
+  browser_start_timeout: 120,
   browser_args: {
-    Firefox: {
-      mode: 'ci',
-      args: [
-        '-headless'
-      ]
-    },
     Chrome: {
-      mode: 'ci',
-      args: [
+      ci: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
-
+        process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
+        '--remote-debugging-port=0',
         '--window-size=1440,900',
-        '--disable-gpu',
-        '--remote-debugging-port=9222'
-      ].filter(Boolean)
-    }
-  }
+      ].filter(Boolean),
+    },
+    Firefox: {
+      ci: ['--headless'],
+    },
+  },
 };


### PR DESCRIPTION
This matches https://github.com/ember-cli/ember-addon-output/blob/v3.21.2/testem.js plus headless Firefox support