### PR TITLE
Update minimum Ember version to 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
-        include:
-          - test-suite: "test:one ember-canary"
-            allow-failure: true
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
     strategy:
       matrix:
         test-suite:
-          - ember-3.0
           - ember-lts-3.4
           - ember-lts-3.8
           - ember-lts-3.12

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -15,15 +15,6 @@ module.exports = function () {
       useYarn: true,
       scenarios: [
         {
-          name: 'ember-3.0',
-          npm: {
-            devDependencies: {
-              'ember-data': '~3.0.0',
-              'ember-source': '~3.0.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=3.0"
+      "ember": ">=3.4"
     }
   }
 }


### PR DESCRIPTION
As long as we support Ember 3.0 we won't be able to adopt native classes. Given that Ember 4.0 is around the corner, it seems fine to drop support for Ember 3.0 (although of course doing so is a breaking change). 3.4 is sufficient since we can use [ember-native-class-polyfill](https://github.com/pzuraq/ember-native-class-polyfill) to add support that.