### PR TITLE
Allow ember-canary build to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
+        include:
+           - test-suite: "test:one ember-canary"
+             allow-failure: true
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
In #626 I accidentially merged a test commit that removed the setting in our CI configuration that allows the build for ember-canary to fail. This restore that.