### PR TITLE
Add recent ember lts to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           - ember-lts-3.12
           - ember-lts-3.16
           - ember-lts-3.20
+          - ember-lts-3.24
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -60,6 +60,15 @@ module.exports = function () {
           },
         },
         {
+          name: 'ember-lts-3.24',
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.24.0',
+              'ember-source': '~3.24.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
This adds the most recent Ember LTS release 3.24 to our testing matrix.