### PR TITLE
add renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,17 @@
+{
+  "extends": ["config:base", ":disableRateLimiting"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "labels": ["dependencies", "renovatebot"],
+  "rangeStrategy": "replace",
+  "packageRules": [
+    {
+      "extends": ["group:allNonMajor", "schedule:weekly"],
+      "lockFileMaintenance": {
+        "enabled": true
+      },
+      "depTypeList": ["devDependencies"]
+    }
+  ]
+}


### PR DESCRIPTION
This adds configuration for Renovate. We group all non-major `devDependencies` updates into one PR per week to reduce noise.