### PR TITLE
Add ember-auto-import@^2.2.3 dependency to ember-release scenario

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -75,6 +75,8 @@ module.exports = function () {
             devDependencies: {
               'ember-data': 'latest',
               'ember-source': releaseUrl,
+              'ember-auto-import': '^2.2.3',
+              webpack: '^5.0.0',
             },
           },
         },


### PR DESCRIPTION
This fixes CI by adding the ember-auto-import@^2.2.3 dependency to the ember-release scenario – Ember 4 requires ember-auto-import@2.