### PR TITLE
Add Ember 3.28 scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-lts-3.24
+          - ember-lts-3.28
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -70,6 +70,15 @@ module.exports = function () {
           },
         },
         {
+          name: 'ember-lts-3.28',
+          npm: {
+            devDependencies: {
+              'ember-data': '~3.28.0',
+              'ember-source': '~3.28.0',
+            },
+          },
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
This adds an ember-try scenario for Ember 3.28 which is the last LTS before 4.0 to our testing matrix.