### PR TITLE
feat: cancel stale actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron:  '0 3 * * *' # daily, at 3am
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Syncs with latest addon blueprint, per https://github.com/ember-cli/ember-cli/pull/9697

This uses Github Action's
[concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
feature to kill the workflow runs of commits that are not the current
head commit of a PR.  `head_ref` is only set for PRs
[source](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context),
which is why we fall back to `ref` (so push workflows will run one job
for each branch for the most recent commit).