### PR TITLE
chore!: drop Node.js 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - run: yarn install --frozen-lockfile
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - run: yarn install --frozen-lockfile
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - run: yarn install
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
 
       - run: yarn install --no-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm publish

--- a/packages/ember-cookies/package.json
+++ b/packages/ember-cookies/package.json
@@ -31,7 +31,7 @@
     "prettier": "2.6.2"
   },
   "engines": {
-    "node": ">= 12.*"
+    "node": ">= 14.*"
   },
   "ember": {
     "edition": "octane"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.70.0"
   },
   "engines": {
-    "node": ">= 12.*"
+    "node": ">= 14.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
#747 is a breaking change hence it might be good time to land this as well cc @marcoow 